### PR TITLE
Add Pywal Dynamic Color Fetching Support

### DIFF
--- a/Glance/Config/AppearanceConfig.swift
+++ b/Glance/Config/AppearanceConfig.swift
@@ -72,6 +72,32 @@ struct AppearanceConfig {
         )
     }
 
+    func applyingPywal(_ pywal: PywalColors) -> AppearanceConfig {
+        return AppearanceConfig(
+            renderingStyle: renderingStyle,
+            roundness: roundness,
+            borderWidth: borderWidth,
+            borderTopOpacity: borderTopOpacity,
+            borderMidOpacity: borderMidOpacity,
+            borderBottomOpacity: borderBottomOpacity,
+            fillOpacity: fillOpacity,
+            glowOpacity: glowOpacity,
+            glowRadius: glowRadius,
+            shadowOpacity: shadowOpacity,
+            shadowRadius: shadowRadius,
+            shadowY: shadowY,
+            blurMaterial: blurMaterial,
+            popupDarkTint: popupDarkTint,
+            popupRoundness: popupRoundness,
+            foregroundColor: pywal.colors[15],
+            accentColor: pywal.colors[4],
+            borderColor: pywal.colors[4],
+            borderColor2: pywal.colors[5],
+            widgetBackgroundColor: pywal.colors[0],
+            glowColor: pywal.colors[4]
+        )
+    }
+
     // MARK: - Hex parsing
 
     static func parseHex(_ hex: String) -> Color? {

--- a/Glance/Config/ConfigManager.swift
+++ b/Glance/Config/ConfigManager.swift
@@ -23,6 +23,14 @@ final class ConfigManager: ObservableObject {
     private let logger = AppLogger.shared
 
     private init() {
+        self.config = Config()
+        self.pywalColors = nil
+        self.initError = nil
+        self.fileWatchSource = nil
+        self.fileDescriptor = -1
+        self.configFilePath = nil
+        self.pywalWatchSource = nil
+        self.pywalFileDescriptor = -1
         loadOrCreateConfigIfNeeded()
         loadPywalColors()
     }

--- a/Glance/Config/ConfigManager.swift
+++ b/Glance/Config/ConfigManager.swift
@@ -5,16 +5,26 @@ import TOMLDecoder
 final class ConfigManager: ObservableObject {
     static let shared = ConfigManager()
 
-    @Published private(set) var config = Config()
+    @Published private(set) var config: Config
     @Published private(set) var initError: String?
+    @Published private(set) var pywalColors: PywalColors? {
+        didSet {
+            if let path = configFilePath {
+                parseConfigFile(at: path)
+            }
+        }
+    }
     
     private var fileWatchSource: DispatchSourceFileSystemObject?
     private var fileDescriptor: CInt = -1
     private(set) var configFilePath: String?
+    private var pywalWatchSource: DispatchSourceFileSystemObject?
+    private var pywalFileDescriptor: CInt = -1
     private let logger = AppLogger.shared
 
     private init() {
         loadOrCreateConfigIfNeeded()
+        loadPywalColors()
     }
 
     private func loadOrCreateConfigIfNeeded() {
@@ -52,7 +62,7 @@ final class ConfigManager: ObservableObject {
             let decoder = TOMLDecoder()
             let rootToml = try decoder.decode(RootToml.self, from: content)
             DispatchQueue.main.async {
-                self.config = Config(rootToml: rootToml)
+                self.config = Config(rootToml: rootToml, pywalColors: self.pywalColors)
             }
         } catch {
             initError = "Error parsing TOML file: \(error.localizedDescription)"
@@ -69,6 +79,9 @@ final class ConfigManager: ObservableObject {
             # aerospace.path = ...
 
             theme = "system" # system, light, dark
+
+            # Use Pywal colors dynamically (overrides preset colors)
+            # use-pywal = false
 
             # Visual preset (overrides style). Available:
             #   liquid-glass, frosted, flat-dark, minimal-strip, system-native, neon
@@ -181,6 +194,53 @@ final class ConfigManager: ObservableObject {
     private func stopWatchingFile() {
         fileWatchSource?.cancel()
         fileWatchSource = nil
+    }
+
+    private func loadPywalColors() {
+        pywalColors = PywalColors()
+        startWatchingPywal()
+    }
+
+    private func startWatchingPywal() {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        let path = homeDir.appendingPathComponent(".cache/wal/colors").path
+        if !FileManager.default.fileExists(atPath: path) { return }
+
+        stopWatchingPywal()
+        pywalFileDescriptor = open(path, O_EVTONLY)
+        if pywalFileDescriptor == -1 {
+            let message = String(cString: strerror(errno))
+            logger.error("Failed to watch pywal file at \(path): \(message)", category: .config)
+            return
+        }
+        pywalWatchSource = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: pywalFileDescriptor,
+            eventMask: [.write, .delete, .rename, .revoke],
+            queue: DispatchQueue.global())
+        pywalWatchSource?.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            let data = self.pywalWatchSource?.data ?? []
+            if data.contains(.delete) || data.contains(.rename) || data.contains(.revoke) {
+                self.stopWatchingPywal()
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+                    self.loadPywalColors()
+                }
+                return
+            }
+            self.pywalColors = PywalColors()
+        }
+        pywalWatchSource?.setCancelHandler { [weak self] in
+            if let fd = self?.pywalFileDescriptor, fd != -1 {
+                close(fd)
+                self?.pywalFileDescriptor = -1
+            }
+        }
+        pywalWatchSource?.resume()
+    }
+
+    private func stopWatchingPywal() {
+        pywalWatchSource?.cancel()
+        pywalWatchSource = nil
     }
 
     func updateConfigValue(key: String, newValue: String) {

--- a/Glance/Config/ConfigModels.swift
+++ b/Glance/Config/ConfigModels.swift
@@ -6,6 +6,7 @@ struct RootToml: Decodable {
     var style: String?
     var preset: String?
     var hotkey: String?
+    var usePywal: Bool?
     var appearanceOverrides: AppearanceOverrides?
     var yabai: YabaiConfig?
     var aerospace: AerospaceConfig?
@@ -14,6 +15,7 @@ struct RootToml: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case theme, style, preset, hotkey, yabai, aerospace, experimental, widgets
+        case usePywal = "use-pywal"
         case appearanceOverrides = "appearance"
     }
 
@@ -22,6 +24,7 @@ struct RootToml: Decodable {
         self.style = nil
         self.preset = nil
         self.hotkey = nil
+        self.usePywal = nil
         self.appearanceOverrides = nil
         self.yabai = nil
         self.aerospace = nil
@@ -34,6 +37,7 @@ struct RootToml: Decodable {
         style = try container.decodeIfPresent(String.self, forKey: .style)
         preset = try container.decodeIfPresent(String.self, forKey: .preset)
         hotkey = try container.decodeIfPresent(String.self, forKey: .hotkey)
+        usePywal = try container.decodeIfPresent(Bool.self, forKey: .usePywal)
         appearanceOverrides = try container.decodeIfPresent(AppearanceOverrides.self, forKey: .appearanceOverrides)
         yabai = try container.decodeIfPresent(YabaiConfig.self, forKey: .yabai)
         aerospace = try container.decodeIfPresent(AerospaceConfig.self, forKey: .aerospace)
@@ -44,22 +48,28 @@ struct RootToml: Decodable {
 
 struct Config {
     let rootToml: RootToml
+    let pywalColors: PywalColors?
 
-    init(rootToml: RootToml = RootToml()) {
+    init(rootToml: RootToml = RootToml(), pywalColors: PywalColors? = nil) {
         self.rootToml = rootToml
+        self.pywalColors = pywalColors
     }
 
     var appearance: AppearanceConfig {
         let base: Preset
         if let presetName = rootToml.preset,
-           let preset = Preset(rawValue: presetName) {
+            let preset = Preset(rawValue: presetName) {
             base = preset
         } else if let style = rootToml.style {
             base = Preset.fromLegacyStyle(style)
         } else {
             base = .liquidGlass
         }
-        return base.defaults.applying(overrides: rootToml.appearanceOverrides)
+        var config = base.defaults.applying(overrides: rootToml.appearanceOverrides)
+        if let pywal = pywalColors, rootToml.usePywal == true {
+            config = config.applyingPywal(pywal)
+        }
+        return config
     }
 
     var barStyle: BarStyle {
@@ -76,6 +86,20 @@ struct Config {
     
     var experimental: ExperimentalConfig {
         rootToml.experimental ?? ExperimentalConfig()
+    }
+}
+
+struct PywalColors {
+    let colors: [Color]
+
+    init?() {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        let path = homeDir.appendingPathComponent(".cache/wal/colors").path
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+        let lines = content.components(separatedBy: .newlines).filter { !$0.isEmpty }
+        guard lines.count >= 16 else { return nil }
+        colors = lines.compactMap { AppearanceConfig.parseHex($0) }
+        guard colors.count == 16 else { return nil }
     }
 }
 

--- a/Glance/Settings/Tabs/GeneralSettingsTab.swift
+++ b/Glance/Settings/Tabs/GeneralSettingsTab.swift
@@ -26,6 +26,7 @@ struct GeneralSettingsTab: View {
     @State private var neonColor: Color = Color(red: 1, green: 0.27, blue: 0.8)
     @State private var neonColor2: Color = Color(red: 0.27, green: 0.8, blue: 1)
     @State private var useGradient: Bool = false
+    @State private var usePywal: Bool = false
     @State private var hotkeyString: String = "ctrl+option+b"
     @State private var hotkeyValid: Bool = true
     @State private var isSyncing: Bool = false
@@ -136,6 +137,11 @@ struct GeneralSettingsTab: View {
 
                 // MARK: - Appearance Overrides
                 SettingsSection(title: "Appearance") {
+                    Toggle("Use Pywal Colors", isOn: $usePywal)
+                        .onChange(of: usePywal) { _, newValue in
+                            guard !isSyncing else { return }
+                            configManager.updateConfigValue(key: "use-pywal", newValue: newValue ? "true" : "false")
+                        }
                     SliderRow(label: "Roundness", value: $roundness, range: 0...50, step: 1, format: "%.0f") {
                         configManager.updateConfigValue(key: "appearance.roundness", newValue: String(Int(roundness)))
                     }
@@ -310,6 +316,7 @@ struct GeneralSettingsTab: View {
         selectedFormation = exp.foreground.formation.rawValue
         formationMargin = exp.foreground.margin
         formationGap = exp.foreground.gap
+        usePywal = root.usePywal ?? false
         hotkeyString = root.hotkey ?? "ctrl+option+b"
         hotkeyValid = true
         syncNeonColors()


### PR DESCRIPTION
     This PR adds support for dynamic color fetching from Pywal (~/.cache/wal/colors). 
     Features:
     - Reads 16 hex colors from wal file
     - Applies colors to all presets (background, foreground, accent, borders, glow)
     - File watching for automatic updates when colors change
     - Config option `use-pywal` to toggle on/off
     - GUI toggle in Settings > General > Appearance
     - Fallback to preset defaults if pywal unavailable
     
     
     
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/a765bb11-3c23-471e-aa2c-afe9b6716a59" />


<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/7af90ced-baad-482e-9f2b-90ea766f83b0" />
